### PR TITLE
Allow Comments in project files

### DIFF
--- a/src/gws
+++ b/src/gws
@@ -237,6 +237,11 @@ function read_projects()
     # Read line by line
     while read line || [[ -n "$line" ]]
     do
+        # Skip if commented line:
+        if [[ "$line" =~ ^# ]]; then
+            continue
+        fi
+
         # Read the line fields
         dir=$(echo $line | cut -d${FIELD_SEP} -f1)
         repo=$(echo $line | cut -d${FIELD_SEP} -f2)


### PR DESCRIPTION
Adds a simple test to allow commenting lines in project configuration
files. Lines starting with '#' are silentely ignored