### PR TITLE
Kill CDPATH to avoid unwanted output.

### DIFF
--- a/src/gws
+++ b/src/gws
@@ -984,6 +984,8 @@ function usage()
 
 # }}}
 
+CDPATH=""
+
 # Except for the special case of "init" in which there is no project files
 if [[ "$1" != "init" ]]; then
     # First move to the first parent directory containing a projects file


### PR DESCRIPTION
This was breaking the git_check_untracked() function. In nb we add
a cd "$1" which was sending the directory into the grep -c.