### PR TITLE
Add selective clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ QuickStart
 
 **and then**
 
-* Clone all missing repositories with `gws update`.
+* Clone all missing repositories with `gws update`, or some specific ones with
+  `gws clone`.
 
 * Do some hacking.
 
@@ -191,6 +192,11 @@ This tool offers some functionalities, among which:
   those unlisted repositories).
 
         $ gws update
+
+* It can also clone a specified selection of non-existing repositories from the
+  projects list, if you don't need all of them right now.
+
+        $ gws clone work/theSoftware
 
 * It can monitor all listed repositories in one command (uncommitted changes,
   untracked changes, branches not synced with origin, ...).

--- a/completions/bash
+++ b/completions/bash
@@ -5,7 +5,7 @@ _gws()
     local cur="${COMP_WORDS[COMP_CWORD]}"
 
     case $COMP_CWORD in
-        1) COMPREPLY=( $(compgen -S " " -W "init update status fetch ff check" -- $cur) $(compgen -S "/" -A directory -- "$cur") )
+        1) COMPREPLY=( $(compgen -S " " -W "init clone update status fetch ff check" -- $cur) $(compgen -S "/" -A directory -- "$cur") )
            ;;
         2) COMPREPLY=( $(compgen -S "/" -A directory -- "$cur") )
            ;;

--- a/completions/zsh
+++ b/completions/zsh
@@ -2,7 +2,7 @@
 # Zsh completion for gws
 
 _path_or_command(){
-    _alternative 'cmds:commands:(init update status fetch ff check)' 'files:filenames:_path_files -/'
+    _alternative 'cmds:commands:(init clone update status fetch ff check)' 'files:filenames:_path_files -/'
 }
 
 _arguments "1::path or command:_path_or_command" "2::filenames:_path_files -/"

--- a/src/gws
+++ b/src/gws
@@ -688,13 +688,18 @@ function cmd_init()
     return 1
 }
 
-# Update command
-function cmd_update()
+# Selective clone command
+function cmd_clone()
 {
     local dir repo remote remote_name remote_url
 
+    if [[ -z "$1" ]]; then
+        echo -e "Usage: ${C_RED}$(basename "$0")${C_OFF} ${C_BLUE}clone${C_OFF} ${C_GREEN}<directory>...${C_OFF}"
+        return 1
+    fi
+
     # For all projects
-    for dir in "${projects_indexes[@]}"
+    for dir in "$@"
     do
         # Get informations about the current project
         repo=$(get_repo_url "${projects[$dir]}")
@@ -742,6 +747,21 @@ function cmd_update()
                 git_add_remote "${dir}" "${remote_name}" "${remote_url}"
             fi
         done
+    done
+
+    return 0
+}
+
+
+# Update command
+function cmd_update()
+{
+    local dir
+
+    # For all projects
+    for dir in "${projects_indexes[@]}"
+    do
+        cmd_clone "$dir"
     done
 
     return 0
@@ -969,6 +989,7 @@ function usage()
     echo -e "where ${C_BLUE}<command>${C_OFF} is:"
     echo -e "    ${C_BLUE}init${C_OFF}   - Detect the repositories and create the projects list"
     echo -e "    ${C_BLUE}update${C_OFF} - Update the workspace to get new repositories from projects list"
+    echo -e "    ${C_BLUE}clone${C_OFF}  - Selectively clone specific repositories from projects list"
     echo -e "    ${C_BLUE}status${C_OFF} - Print status for all repositories in the workspace"
     echo -e "    ${C_BLUE}fetch${C_OFF}  - Print status for all repositories in the workspace, but fetch the origin before"
     echo -e "    ${C_BLUE}ff${C_OFF}     - Print status for all repositories in the workspace, but fast forward from origin before"
@@ -1009,9 +1030,12 @@ if [[ "$1" != "init" ]]; then
     # If a path is specified as second argument, limit projects to the ones matching
     # the path
     if [[ -n "$2" ]]; then
-        error_msg="${C_RED}The directory '$2' is not found.${C_OFF}"
-        projects_list=$(keep_prefixed_projects "$2") || (echo -e "$error_msg" && exit 1) || exit 1
-        projects_indexes=( ${projects_list} )
+        # But don't error out in the case of "clone", becuase the directory will probably not exist
+        if [[ "$1" != "clone" ]]; then
+            error_msg="${C_RED}The directory '$2' is not found.${C_OFF}"
+            projects_list=$(keep_prefixed_projects "$2") || (echo -e "$error_msg" && exit 1) || exit 1
+            projects_indexes=( ${projects_list} )
+        fi
     fi
 fi
 
@@ -1020,6 +1044,10 @@ fi
 case $1 in
     "init")
         cmd_init
+        ;;
+    "clone")
+        shift
+        cmd_clone "$@"
         ;;
     "update")
         cmd_update

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,2 +1,3 @@
 Workspace/
+Workspace_test_clone/
 Workspace_test_update/

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,1 +1,2 @@
 Workspace/
+Workspace_test_update/

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,6 +3,7 @@ GWS_SCRIPT=$(PWD)/../src/gws
 
 # Workspace folder name
 WORKSPACE=Workspace
+TEST_CLONE_WORKSPACE=$(WORKSPACE)_test_clone
 TEST_UPDATE_WORKSPACE=$(WORKSPACE)_test_update
 
 prepare:
@@ -46,11 +47,22 @@ perturbate:
 	cd $(WORKSPACE)/tools/coursera-dl; touch test; git add test
 
 clean:
-	rm -rf $(WORKSPACE) $(TEST_UPDATE_WORKSPACE)
+	rm -rf $(WORKSPACE) $(TEST_CLONE_WORKSPACE) $(TEST_UPDATE_WORKSPACE)
 
-.PHONY: tests perturbate test_project_gws test_status test_update test_check test_fetch test_ff clean
+.PHONY: tests perturbate test_project_gws test_status test_clone test_update test_check test_fetch test_ff clean
 
-tests: test_update
+tests: test_clone test_update
+
+test_clone:
+	rm -rf $(TEST_CLONE_WORKSPACE)
+	mkdir -p rf $(TEST_CLONE_WORKSPACE)
+	cp test_update_projects.gws $(TEST_CLONE_WORKSPACE)/.projects.gws
+	cp test_update_ignore.gws $(TEST_CLONE_WORKSPACE)/.ignore.gws
+	cd $(TEST_CLONE_WORKSPACE); $(GWS_SCRIPT) clone ignoring/gws gws2 >/dev/null
+	# clone command clones only the named project, and overrides ignore settings
+	test -d $(TEST_CLONE_WORKSPACE)/ignoring/gws
+	test ! -d $(TEST_CLONE_WORKSPACE)/gws
+	test -d $(TEST_CLONE_WORKSPACE)/gws2
 
 test_update:
 	rm -rf $(TEST_UPDATE_WORKSPACE)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,21 +15,21 @@ $(WORKSPACE):
 	mkdir -p $(WORKSPACE)/{work,tools,ignoring}
 	git clone https://github.com/karpathy/neuraltalk.git $(WORKSPACE)/work/neuraltalk
 	git clone https://github.com/sameersbn/docker-gitlab.git $(WORKSPACE)/work/docker-gitlab
-	cd $(WORKSPACE)/work/docker-gitlab; git co gh-pages
+	cd $(WORKSPACE)/work/docker-gitlab; git checkout gh-pages
 	git clone https://github.com/harelba/q $(WORKSPACE)/tools/q
-	cd $(WORKSPACE)/tools/q; git co gh-pages
+	cd $(WORKSPACE)/tools/q; git checkout gh-pages
 	cd $(WORKSPACE)/tools/q; git remote add myone http://coool
 	cd $(WORKSPACE)/tools/q; git remote add upstream testurl
 	git clone https://github.com/buildinspace/peru $(WORKSPACE)/tools/peru
 	git clone https://github.com/dgorissen/coursera-dl $(WORKSPACE)/tools/coursera-dl
-	cd $(WORKSPACE)/tools/coursera-dl; git co master
+	cd $(WORKSPACE)/tools/coursera-dl; git checkout master
 	git init $(WORKSPACE)/tools/emptyyyy
 	git init $(WORKSPACE)/tools/another
 	cd $(WORKSPACE)/tools/another; \
-		git co -b aaaaabbbbbcccccdddddeeeeefffffggggghhhhhiiiiiccccc; \
-		touch test; git add test; git ci -m message 
+		git checkout -b aaaaabbbbbcccccdddddeeeeefffffggggghhhhhiiiiiccccc; \
+		touch test; git add test; git commit -m message
 	git clone https://github.com/StreakyCobra/gws $(WORKSPACE)/ignoring/gws
-	cd $(WORKSPACE)/ignoring/gws; git co develop
+	cd $(WORKSPACE)/ignoring/gws; git checkout develop
 
 $(WORKSPACE)/.ignore.gws: $(WORKSPACE)
 	echo "^ignoring/" > $@
@@ -39,8 +39,8 @@ $(WORKSPACE)/.project.gws: $(WORKSPACE)
 
 perturbate:
 	cd $(WORKSPACE)/work/neuraltalk; touch test
-	cd $(WORKSPACE)/work/docker-gitlab; git co master; git reset --hard HEAD^
-	cd $(WORKSPACE)/tools/q; touch test; git add test; git ci -m message
+	cd $(WORKSPACE)/work/docker-gitlab; git checkout master; git reset --hard HEAD^
+	cd $(WORKSPACE)/tools/q; touch test; git add test; git commit -m message
 	cd $(WORKSPACE)/tools; rm -rf peru
 	cd $(WORKSPACE)/tools/coursera-dl; touch test; git add test
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,6 +3,7 @@ GWS_SCRIPT=$(PWD)/../src/gws
 
 # Workspace folder name
 WORKSPACE=Workspace
+TEST_UPDATE_WORKSPACE=$(WORKSPACE)_test_update
 
 prepare:
 	$(MAKE) clean				# Clean existing folder
@@ -45,6 +46,19 @@ perturbate:
 	cd $(WORKSPACE)/tools/coursera-dl; touch test; git add test
 
 clean:
-	rm -rf $(WORKSPACE)
+	rm -rf $(WORKSPACE) $(TEST_UPDATE_WORKSPACE)
 
 .PHONY: tests perturbate test_project_gws test_status test_update test_check test_fetch test_ff clean
+
+tests: test_update
+
+test_update:
+	rm -rf $(TEST_UPDATE_WORKSPACE)
+	mkdir -p rf $(TEST_UPDATE_WORKSPACE)
+	cp test_update_projects.gws $(TEST_UPDATE_WORKSPACE)/.projects.gws
+	cp test_update_ignore.gws $(TEST_UPDATE_WORKSPACE)/.ignore.gws
+	cd $(TEST_UPDATE_WORKSPACE); $(GWS_SCRIPT) update >/dev/null
+	# update command clones all projects except ignored ones
+	test ! -d $(TEST_UPDATE_WORKSPACE)/ignoring/gws
+	test -d $(TEST_UPDATE_WORKSPACE)/gws
+	test -d $(TEST_UPDATE_WORKSPACE)/gws2

--- a/tests/test_update_ignore.gws
+++ b/tests/test_update_ignore.gws
@@ -1,0 +1,1 @@
+^ignoring/

--- a/tests/test_update_projects.gws
+++ b/tests/test_update_projects.gws
@@ -1,0 +1,3 @@
+ignoring/gws | https://github.com/StreakyCobra/gws
+gws | https://github.com/StreakyCobra/gws
+gws2 | https://github.com/StreakyCobra/gws


### PR DESCRIPTION
Hi! Thanks for making this really good tool!

These changes add a `clone` command, which works like `update` but only clones repositories named on the command line. This is useful if you have a `.projects.gws` file in a large team with lots of repositories, but only need a few of them checked out.