### PR TITLE
Make gws find submodules

### DIFF
--- a/src/gws
+++ b/src/gws
@@ -724,7 +724,7 @@ function cmd_init()
     declare -a found
 
     # Prepare the list of all existing projects, sorted
-    found=( $(find ./* -type d -name "$GIT_FOLDER" | sed -e "s#/${GIT_FOLDER}\$#/#" | cut -c 3- | sort) )
+    found=( $(find ./* -type d,f -name "$GIT_FOLDER" | sed -e "s#/${GIT_FOLDER}\$#/#" | cut -c 3- | sort) )
     found=( $(remove_prefixed found[@]) )
 
     # Create the list of repositories
@@ -1077,7 +1077,7 @@ function cmd_check()
     readarray -t projects_ignored < <(comm -23 <(for a in "${projects_all_indexes[@]}"; do echo "$a"; done | sort) <(for a in "${projects_indexes[@]}"; do echo "$a"; done | sort))
 
     # Prepare list of all projects, existing or missing, sorted with no duplicates
-    found=( $(find ./* -type d -name "$GIT_FOLDER" | sed -e "s#/${GIT_FOLDER}\$##" | cut -c 3- | sort) )
+    found=( $(find ./* -type d,f -name "$GIT_FOLDER" | sed -e "s#/${GIT_FOLDER}\$##" | cut -c 3- | sort) )
     all=( "${found[@]}" "${projects_all_indexes[@]}" )
     readarray -t all < <(for a in "${all[@]}"; do echo "$a"; done | sort -u)
 


### PR DESCRIPTION
Right now you cant run `gws init` inside a repository with submodules since they have `.git` files and not folders.
It will not affect `gws` when ran outside of a git repository.